### PR TITLE
Don't use `default_aes` directly

### DIFF
--- a/R/ggseqtrplot.R
+++ b/R/ggseqtrplot.R
@@ -85,7 +85,7 @@ ggseqtrplot <- function(seqdata,
 
   if (is.null(attributes(seqdata)$weights)) weighted <- FALSE
 
-  if (is.null(labsize)) labsize <- GeomLabel$default_aes$size
+  if (is.null(labsize)) labsize <- 11 / .pt
 
   if (!is.null(labsize) & (length(labsize) > 1 | !is.numeric(labsize))) {
     stop("labsize must be a single number")


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We've changed many `default_aes` fields and these now more frequently contain unevaluated expressions.
Your code didn't expect an unevaluated expression, so this PR exchanges it with a value.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
