### PR TITLE
remove dependency on hrbrthemes, adjust vignette accordingly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Imports:
 Suggests: 
     covr,
     ggthemes,
-    hrbrthemes,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)

--- a/vignettes/ggseqplot.Rmd
+++ b/vignettes/ggseqplot.Rmd
@@ -28,7 +28,7 @@ old <- options()
 on.exit(options(old))
 options(rmarkdown.html_vignette.check_title = FALSE)
 
-pkgs <- c("colorspace", "ggplot2", "ggthemes", "ggseqplot", "hrbrthemes", 
+pkgs <- c("colorspace", "ggplot2", "ggthemes", "ggseqplot",
           "patchwork", "forcats", "ggh4x", "purrr", "TraMineR")
 
 # Load all packages to library and adjust options
@@ -126,7 +126,6 @@ pkgs <- c("colorspace", # for using colors palettes
           "ggh4x", # for proportional panel sized with `force_panelsizes`
           "ggplot2", # for using all the ggplot2 functions 
           "ggthemes", # for getting access to the canva_palettes
-          "hrbrthemes", # for using the ggplot2 theme `theme_ipsum` 
           "patchwork", # for working with plot types built with patchwork
           "purrr", # used in the grouped rplot example
           "TraMineR") # the ultimate sequence analysis suite
@@ -285,10 +284,14 @@ ggseqdplot(actcal.seq) +
   labs(title = "State distribution plot",
        x = "Month") +
   guides(fill=guide_legend(title="Alphabet")) +
-  theme_ipsum(base_family = "") +
-  theme(plot.title = element_text(size = 30, 
-                                  margin=margin(0,0,20,0)),
-        plot.title.position = "plot")
+  theme_minimal(base_family = "") +
+  theme(plot.title = element_text(size = 30, margin=margin(0,0,20,0)),
+        plot.title.position = "plot",
+        axis.title.x = element_text(hjust = 1, 
+                                    vjust = -1),
+        axis.title.y = element_text(hjust = 1, 
+                                    vjust = 1),
+        axis.title = element_text(size = 9))
 ```
 
 In the following example, we use two `ggseqdplot` calls to create plots of the 
@@ -313,11 +316,16 @@ p2 <- ggseqdplot(ex1.seq,
 p1 + p2 + 
   plot_layout(guides = "collect") &
   scale_fill_manual(values= canva_palettes$`Fun and tropical`[1:4]) &
-  theme_ipsum(base_family = "") &
+  theme_minimal(base_family = "") &
   theme(plot.title = element_text(size = 20,
                                   hjust = 0.5),
         legend.position = "bottom",
-        legend.title = element_blank())
+        legend.title = element_blank(),
+        axis.title.x = element_text(hjust = 1, 
+                                    vjust = -1),
+        axis.title.y = element_text(hjust = 1, 
+                                    vjust = 1),
+        axis.title = element_text(size = 9))
 ```
 
 
@@ -505,10 +513,15 @@ ggseqrfplot(biofam.seq, diss = diss, k = 12)
 
 ## adjusted version
 ggseqrfplot(biofam.seq, diss = diss, k = 12) &
-  theme_ipsum(base_family = "") &
+  theme_minimal(base_family = "") &
   theme(legend.position = "bottom",
         legend.title = element_blank(),
-        plot.title = element_text(size = 12)) &
+        plot.title = element_text(size = 12),
+        axis.title.x = element_text(hjust = 1, 
+                                    vjust = -1),
+        axis.title.y = element_text(hjust = 1, 
+                                    vjust = 1),
+        axis.title = element_text(size = 9)) &
   plot_annotation(title = "Relative Frequency Sequence Plot")
 ```
 


### PR DESCRIPTION
There is a chain of reverse dependency issues on CRAN stemming from removal of `extrafonts` which also affects `ggseqplot` via `hrbrthemes`. This pull request removes the dependency on `hrbrthemes` by removing it from `DESCRIPTION` and adjusts the vignette so that instead of `theme_ipsum`  from `hrbrthemes`, the plots now use `theme_minimal` with few tweaks to make the plots resemble the ipsum theme, at least in terms of the axis title locations and font sizes.